### PR TITLE
Color Swatch Codes & Names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3353,6 +3353,11 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
       "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
     },
+    "chroma-js": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-1.4.1.tgz",
+      "integrity": "sha512-jTwQiT859RTFN/vIf7s+Vl/Z2LcMrvMv3WUFmd/4u76AdlFC0NTNgqEEFPcRiHmAswPsMiQEDZLM8vX8qXpZNQ=="
+    },
     "chrome-trace-event": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz",
@@ -3496,6 +3501,14 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-namer": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/color-namer/-/color-namer-1.3.0.tgz",
+      "integrity": "sha1-tUTgm+vXEzwAi+i4AG5vguukAR0=",
+      "requires": {
+        "chroma-js": "^1.3.4"
+      }
     },
     "color-string": {
       "version": "1.5.3",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "color-namer": "^1.3.0",
     "node-sass": "^4.12.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/src/components/App/_App.scss
+++ b/src/components/App/_App.scss
@@ -3,33 +3,3 @@
   display: grid;
   grid-template-rows: 50px 1fr;
 }
-
-.App-logo {
-  animation: App-logo-spin infinite 20s linear;
-  height: 40vmin;
-  pointer-events: none;
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}

--- a/src/components/Color/Color.js
+++ b/src/components/Color/Color.js
@@ -1,12 +1,39 @@
-import React from 'react';
+import React, { Component } from 'react';
+import namer from 'color-namer';
 
-export function Color({hex}) {
+export class Color extends Component {
 
-  let style = { backgroundColor: hex };
+  determineLightness(hex) {
+    const color = hex.substring(1);
+    const rgbColor = parseInt(color, 16);
 
-  return (
-    <div style={style} className="Color">
-      { hex }
-    </div>
-  )
+    const red = (rgbColor >> 16) & 0xff;
+    const green = (rgbColor >> 8) & 0xff;
+    const blue = (rgbColor >> 0) & 0xff;
+
+    const lightLevel = 0.2126 * red + 0.7152 * green + 0.0722 * blue; 
+
+    if (lightLevel < 80) return true;
+  }
+
+  hexToName(hex) {
+    let names = namer(hex);
+    return names.ntc[0].name;
+  }
+
+  render() {
+    const { hex } = this.props;
+    const style = { backgroundColor: hex };
+
+    let lightClass = this.determineLightness(hex) ? 'light' : '';
+
+    let colorName = this.hexToName(hex).toUpperCase();
+
+    return (
+      <div style={style} className="Color">
+        <p className={`hex ${lightClass}`}>{ hex }</p>
+        <p className={`name ${lightClass}`}>{ colorName }</p>
+      </div>
+    )
+  }
 }

--- a/src/components/Color/_Color.scss
+++ b/src/components/Color/_Color.scss
@@ -1,3 +1,29 @@
 .Color {
-  width: 18%; height: 100%;
+  width: 20%; height: 100%;
+  box-sizing: border-box;
+  padding: 10px;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+
+  .hex,
+  .name {
+    color: #1f2d3d;
+    opacity: .4;
+    font-weight: 800;
+    font-size: 40px;
+    margin: 2px 0;
+  }
+
+  .name {
+    font-weight: 800;
+    font-size: 16px;
+  }
+
+  .light {
+    color: #fff;
+  }
+
 }

--- a/src/components/Nav/_Nav.scss
+++ b/src/components/Nav/_Nav.scss
@@ -1,8 +1,8 @@
 .Nav {
-  width: 100%; height: 50px;
+  height: 50px;
 
   position: absolute;
-  top: 50px;
+  top: 50px; left: 0; right: 0;
 
   display: flex;
   justify-content: center;
@@ -29,5 +29,15 @@
     position: absolute;
     right: 0;
   }
+
+  // .tutorial::before {
+  //   content: "";
+  //   position: absolute;
+  //   top: 50px;
+  // }
+
+  // .tutorial:hover::before {
+  //   content: "test"
+  // }
 
 }


### PR DESCRIPTION
### Changes Made:
- Installed `color-namer` dependency
- `HEX codes` centered on color swatches and styled for more readability
- Added `color names` to match `HEX codes` on color swatches
- `Color names` & `HEX codes` now change lightness depending on background swatch color

### Relevant Screenshots:
#### Before:
<img width="1500" alt="Screen Shot 2019-05-07 at 4 47 34 PM" src="https://user-images.githubusercontent.com/44077214/57337756-e6982e00-70e7-11e9-8029-2e4fccb60209.png">
#### After:
<img width="1500" alt="Screen Shot 2019-05-07 at 4 46 43 PM" src="https://user-images.githubusercontent.com/44077214/57337752-e26c1080-70e7-11e9-8a72-28e967abc41f.png">

#### Message for reviewer:
Wassup

#### Testing complete?
- [ ] Yes
- [x] Not yet

#### Final checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas